### PR TITLE
Re-enable the acronyms.tex build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 #for dependency you want all tex files  but for acronyms you do not want to include the acronyms file itself.
-tex=$(filter-out $(wildcard *acronyms.tex) , $(wildcard *.tex))  
+tex=$(filter-out $(wildcard *acronyms.tex) , $(wildcard *.tex))
 
 
 SRC= LSE-150.tex
@@ -9,7 +9,7 @@ OBJ=$(SRC:.tex=.pdf)
 #Default when you type make
 all: $(OBJ)
 
-$(OBJ): $(tex) # for now lander can not do this acronyms.tex
+$(OBJ): $(tex) acronyms.tex
 	latexmk -bibtex -xelatex -f $(SRC)
 
 #The generateAcronyms.py  script is in lsst-texmf/bin - put that in the path
@@ -19,6 +19,3 @@ acronyms.tex :$(tex) myacronyms.txt
 clean :
 	latexmk -c
 	rm *.pdf *.nav *.bbl *.xdv *.snm
-
-
-


### PR DESCRIPTION
The lsst-texmf docker image now has a fully working generateAcronyms.py.